### PR TITLE
Migrate publish script to new Maven Central endpoint

### DIFF
--- a/gleap/maven-push.gradle
+++ b/gleap/maven-push.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 
 def getReleaseRepositoryUrl() {
     return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            : "https://central.sonatype.com/api/v1/publish"
 }
 
 def getRepositoryUsername() {


### PR DESCRIPTION
## Summary
- update maven publish URL to `central.sonatype.com`

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686ce39d3c70832cb7d313c23d60043b