### PR TITLE
fix(141630): recover session on widget open after offline app launch

### DIFF
--- a/gleap/build.gradle
+++ b/gleap/build.gradle
@@ -28,7 +28,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 33
-        buildConfigField "String", "VERSION_NAME", "\"15.4.0\""
+        buildConfigField "String", "VERSION_NAME", "\"16.4.0\""
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/gleap/src/main/java/io/gleap/Gleap.java
+++ b/gleap/src/main/java/io/gleap/Gleap.java
@@ -1,6 +1,7 @@
 package io.gleap;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.Application;
 import android.content.Intent;
 import android.net.Uri;
@@ -16,9 +17,11 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.net.ssl.HttpsURLConnection;
 
+import gleap.io.gleap.R;
 import io.gleap.callbacks.AiToolExecutedCallback;
 import io.gleap.callbacks.GleapAgentToolHandler;
 import io.gleap.callbacks.ConfigLoadedCallback;
@@ -49,6 +52,7 @@ public class Gleap implements iGleap {
     public static boolean internalCloseWidgetOnExternalLinkOpen = false;
     private static boolean isInitialized = false;
     private static OpenPushAction openPushAction;
+    private static final AtomicBoolean sessionRecoveryInProgress = new AtomicBoolean(false);
 
     private Gleap() {
     }
@@ -234,8 +238,7 @@ public class Gleap implements iGleap {
                         @Override
                         public void run() throws RuntimeException {
                             try {
-                                if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null &&
-                                        GleapSessionController.getInstance().isSessionLoaded() && instance != null) {
+                                if (!GleapDetectorUtil.isIsRunning() && isGleapReady() && instance != null) {
                                     try {
                                         if (screenshotTaker != null) {
                                             JSONObject message = new JSONObject();
@@ -247,6 +250,13 @@ public class Gleap implements iGleap {
                                     } catch (Exception e) {
                                         handleError(e, "openConversations - inner");
                                     }
+                                } else if (!GleapDetectorUtil.isIsRunning() && instance != null) {
+                                    recoverSessionAndRetry(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            openConversations(hideBackButton);
+                                        }
+                                    });
                                 }
                             } catch (Error | Exception ignore) {
                                 handleError(ignore, "openConversations - middle");
@@ -272,8 +282,7 @@ public class Gleap implements iGleap {
                         @Override
                         public void run() throws RuntimeException {
                             try {
-                                if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null &&
-                                        GleapSessionController.getInstance().isSessionLoaded() && instance != null) {
+                                if (!GleapDetectorUtil.isIsRunning() && isGleapReady() && instance != null) {
                                     try {
                                         if (screenshotTaker != null) {
                                             JSONObject message = new JSONObject();
@@ -286,6 +295,13 @@ public class Gleap implements iGleap {
                                     } catch (Exception e) {
                                         handleError(e, "run");
                                     }
+                                } else if (!GleapDetectorUtil.isIsRunning() && instance != null) {
+                                    recoverSessionAndRetry(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            openConversation(shareToken);
+                                        }
+                                    });
                                 }
                             } catch (Error | Exception ignore) {
                                 handleError(ignore, "run");
@@ -333,8 +349,7 @@ public class Gleap implements iGleap {
                         @Override
                         public void run() throws RuntimeException {
                             try {
-                                if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null &&
-                                        GleapSessionController.getInstance().isSessionLoaded() && instance != null) {
+                                if (!GleapDetectorUtil.isIsRunning() && isGleapReady() && instance != null) {
                                     try {
                                         if (screenshotTaker != null) {
                                             screenshotTaker.takeScreenshot(type);
@@ -342,6 +357,13 @@ public class Gleap implements iGleap {
                                     } catch (Exception e) {
                                         handleError(e, "run");
                                     }
+                                } else if (type == SurveyType.NONE && !GleapDetectorUtil.isIsRunning() && instance != null) {
+                                    recoverSessionAndRetry(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            open(type);
+                                        }
+                                    });
                                 }
                             } catch (Error | Exception ignore) {
                                 handleError(ignore, "run");
@@ -353,6 +375,96 @@ public class Gleap implements iGleap {
             });
         } catch (Error | Exception ignore) {
             handleError(ignore, "run");
+        }
+    }
+
+    /**
+     * Whether the session and the remote config have actually been loaded — after an
+     * offline app launch the session start is marked as done without ever succeeding,
+     * so the widget could not load and opening it would silently do nothing.
+     */
+    private static boolean isGleapReady() {
+        return GleapSessionController.getInstance() != null
+                && GleapSessionController.getInstance().isSessionLoaded()
+                && GleapSessionController.getInstance().getUserSession() != null
+                && GleapConfig.getInstance().getPlainConfig() != null;
+    }
+
+    /**
+     * Attempts to restart the Gleap session (and config load) when the widget is opened
+     * explicitly but Gleap never finished loading (e.g. the app was launched offline).
+     * On success the widget opens as requested; on failure the user gets the same offline
+     * alert the widget shows when it fails to load mid-session.
+     */
+    private void recoverSessionAndRetry(final Runnable retryOpen) {
+        if (!sessionRecoveryInProgress.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            new GleapBaseSessionService(new GleapBaseSessionService.SessionLoadedCallback() {
+                @Override
+                public void invoke(boolean success) {
+                    try {
+                        if (!success) {
+                            sessionRecoveryInProgress.set(false);
+                            showOfflineAlert();
+                            return;
+                        }
+
+                        if (GleapConfig.getInstance().getPlainConfig() != null) {
+                            sessionRecoveryInProgress.set(false);
+                            retryOpen.run();
+                            return;
+                        }
+
+                        // The config never loaded either — fetch it before opening the widget.
+                        new ConfigLoader(new OnHttpResponseListener() {
+                            @Override
+                            public void onTaskComplete(JSONObject response) throws GleapAlreadyInitialisedException {
+                                sessionRecoveryInProgress.set(false);
+                                if (GleapConfig.getInstance().getPlainConfig() != null) {
+                                    GleapDetectorUtil.clearAllDetectors();
+                                    new GleapListener(false).onTaskComplete(response);
+                                    retryOpen.run();
+                                } else {
+                                    showOfflineAlert();
+                                }
+                            }
+                        }).execute(GleapBug.getInstance());
+                    } catch (Error | Exception exception) {
+                        sessionRecoveryInProgress.set(false);
+                        handleError(exception, "recoverSessionAndRetry - callback");
+                    }
+                }
+            }).execute();
+        } catch (Error | Exception exception) {
+            sessionRecoveryInProgress.set(false);
+            handleError(exception, "recoverSessionAndRetry");
+        }
+    }
+
+    private static void showOfflineAlert() {
+        try {
+            final Activity activity = ActivityUtil.getCurrentActivity();
+            if (activity == null) {
+                return;
+            }
+            activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        AlertDialog alertDialog = new AlertDialog.Builder(activity)
+                                .setPositiveButton(activity.getString(R.string.gleap_alert_no_internet_accept), null)
+                                .create();
+                        alertDialog.setTitle(activity.getString(R.string.gleap_alert_no_internet_title));
+                        alertDialog.setMessage(activity.getString(R.string.gleap_alert_no_internet_subtitle));
+                        alertDialog.show();
+                    } catch (Error | Exception ignore) {
+                    }
+                }
+            });
+        } catch (Error | Exception ignore) {
         }
     }
 
@@ -372,8 +484,7 @@ public class Gleap implements iGleap {
                         @Override
                         public void run() throws RuntimeException {
                             try {
-                                if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null &&
-                                        GleapSessionController.getInstance().isSessionLoaded() && instance != null) {
+                                if (!GleapDetectorUtil.isIsRunning() && isGleapReady() && instance != null) {
                                     try {
                                         if (screenshotTaker != null) {
                                             JSONObject message = new JSONObject();
@@ -385,6 +496,13 @@ public class Gleap implements iGleap {
                                     } catch (Exception e) {
                                         handleError(e, "run");
                                     }
+                                } else if (!GleapDetectorUtil.isIsRunning() && instance != null) {
+                                    recoverSessionAndRetry(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            openChecklists(showBackButton);
+                                        }
+                                    });
                                 }
                             } catch (Error | Exception ignore) {
                                 handleError(ignore, "run");
@@ -415,8 +533,7 @@ public class Gleap implements iGleap {
                         @Override
                         public void run() throws RuntimeException {
                             try {
-                                if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null &&
-                                        GleapSessionController.getInstance().isSessionLoaded() && instance != null) {
+                                if (!GleapDetectorUtil.isIsRunning() && isGleapReady() && instance != null) {
                                     try {
                                         if (screenshotTaker != null) {
                                             JSONObject message = new JSONObject();
@@ -429,6 +546,13 @@ public class Gleap implements iGleap {
                                     } catch (Exception e) {
                                         handleError(e, "run");
                                     }
+                                } else if (!GleapDetectorUtil.isIsRunning() && instance != null) {
+                                    recoverSessionAndRetry(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            openChecklist(checklistId, showBackButton);
+                                        }
+                                    });
                                 }
                             } catch (Error | Exception ignore) {
                                 handleError(ignore, "run");
@@ -459,8 +583,7 @@ public class Gleap implements iGleap {
                         @Override
                         public void run() throws RuntimeException {
                             try {
-                                if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null &&
-                                        GleapSessionController.getInstance().isSessionLoaded() && instance != null) {
+                                if (!GleapDetectorUtil.isIsRunning() && isGleapReady() && instance != null) {
                                     try {
                                         if (screenshotTaker != null) {
                                             JSONObject message = new JSONObject();
@@ -473,6 +596,13 @@ public class Gleap implements iGleap {
                                     } catch (Exception e) {
                                         handleError(e, "run");
                                     }
+                                } else if (!GleapDetectorUtil.isIsRunning() && instance != null) {
+                                    recoverSessionAndRetry(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            startChecklist(outboundId, showBackButton);
+                                        }
+                                    });
                                 }
                             } catch (Error | Exception ignore) {
                                 handleError(ignore, "run");
@@ -515,8 +645,7 @@ public class Gleap implements iGleap {
                         @Override
                         public void run() throws RuntimeException {
                             try {
-                                if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null &&
-                                        GleapSessionController.getInstance().isSessionLoaded() && instance != null) {
+                                if (!GleapDetectorUtil.isIsRunning() && isGleapReady() && instance != null) {
                                     try {
                                         if (screenshotTaker != null) {
                                             JSONObject message = new JSONObject();
@@ -528,6 +657,13 @@ public class Gleap implements iGleap {
                                     } catch (Exception e) {
                                         handleError(e, "run");
                                     }
+                                } else if (!GleapDetectorUtil.isIsRunning() && instance != null) {
+                                    recoverSessionAndRetry(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            openNews(showBackButton);
+                                        }
+                                    });
                                 }
                             } catch (Error | Exception ignore) {
                                 handleError(ignore, "run");
@@ -568,8 +704,7 @@ public class Gleap implements iGleap {
                         @Override
                         public void run() throws RuntimeException {
                             try {
-                                if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null &&
-                                        GleapSessionController.getInstance().isSessionLoaded() && instance != null) {
+                                if (!GleapDetectorUtil.isIsRunning() && isGleapReady() && instance != null) {
                                     try {
                                         if (screenshotTaker != null) {
                                             JSONObject message = new JSONObject();
@@ -582,6 +717,13 @@ public class Gleap implements iGleap {
                                     } catch (Exception e) {
                                         handleError(e, "run");
                                     }
+                                } else if (!GleapDetectorUtil.isIsRunning() && instance != null) {
+                                    recoverSessionAndRetry(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            startBot(botId, showBackButton);
+                                        }
+                                    });
                                 }
                             } catch (Error | Exception ignore) {
                                 handleError(ignore, "run");
@@ -610,8 +752,7 @@ public class Gleap implements iGleap {
                         @Override
                         public void run() throws RuntimeException {
                             try {
-                                if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null &&
-                                        GleapSessionController.getInstance().isSessionLoaded() && instance != null) {
+                                if (!GleapDetectorUtil.isIsRunning() && isGleapReady() && instance != null) {
                                     try {
                                         if (screenshotTaker != null) {
                                             JSONObject message = new JSONObject();
@@ -624,6 +765,13 @@ public class Gleap implements iGleap {
                                     } catch (Exception e) {
                                         handleError(e, "run");
                                     }
+                                } else if (!GleapDetectorUtil.isIsRunning() && instance != null) {
+                                    recoverSessionAndRetry(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            openNewsArticle(articleId, showBackButton);
+                                        }
+                                    });
                                 }
                             } catch (Error | Exception ignore) {
                                 handleError(ignore, "run");
@@ -682,8 +830,7 @@ public class Gleap implements iGleap {
                     Runnable gleapRunnable = new Runnable() {
                         @Override
                         public void run() throws RuntimeException {
-                            if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null
-                                    && GleapSessionController.getInstance().isSessionLoaded()
+                            if (!GleapDetectorUtil.isIsRunning() && isGleapReady()
                                     && Gleap.getInstance() != null) {
                                 try {
                                     JSONObject data = new JSONObject();
@@ -697,6 +844,13 @@ public class Gleap implements iGleap {
                                 } catch (Exception e) {
                                     handleError(e, "run");
                                 }
+                            } else if (!GleapDetectorUtil.isIsRunning() && Gleap.getInstance() != null) {
+                                recoverSessionAndRetry(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        startFeedbackFlow(feedbackFlow, showBackButton);
+                                    }
+                                });
                             }
                         }
                     };
@@ -757,8 +911,7 @@ public class Gleap implements iGleap {
                     Runnable gleapRunnable = new Runnable() {
                         @Override
                         public void run() throws RuntimeException {
-                            if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null
-                                    && GleapSessionController.getInstance().isSessionLoaded()
+                            if (!GleapDetectorUtil.isIsRunning() && isGleapReady()
                                     && Gleap.getInstance() != null) {
                                 try {
 
@@ -770,6 +923,13 @@ public class Gleap implements iGleap {
                                 } catch (Exception e) {
                                     handleError(e, "run");
                                 }
+                            } else if (!GleapDetectorUtil.isIsRunning() && Gleap.getInstance() != null) {
+                                recoverSessionAndRetry(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        openHelpCenter(showBackButton);
+                                    }
+                                });
                             }
                         }
                     };
@@ -796,8 +956,7 @@ public class Gleap implements iGleap {
                     Runnable gleapRunnable = new Runnable() {
                         @Override
                         public void run() throws RuntimeException {
-                            if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null
-                                    && GleapSessionController.getInstance().isSessionLoaded()
+                            if (!GleapDetectorUtil.isIsRunning() && isGleapReady()
                                     && Gleap.getInstance() != null) {
                                 try {
 
@@ -810,6 +969,13 @@ public class Gleap implements iGleap {
                                 } catch (Exception e) {
                                     handleError(e, "run");
                                 }
+                            } else if (!GleapDetectorUtil.isIsRunning() && Gleap.getInstance() != null) {
+                                recoverSessionAndRetry(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        askAI(question, showBackButton);
+                                    }
+                                });
                             }
                         }
                     };
@@ -836,8 +1002,7 @@ public class Gleap implements iGleap {
                     Runnable gleapRunnable = new Runnable() {
                         @Override
                         public void run() throws RuntimeException {
-                            if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null
-                                    && GleapSessionController.getInstance().isSessionLoaded()
+                            if (!GleapDetectorUtil.isIsRunning() && isGleapReady()
                                     && Gleap.getInstance() != null) {
                                 try {
 
@@ -850,6 +1015,13 @@ public class Gleap implements iGleap {
                                 } catch (Exception e) {
                                     handleError(e, "run");
                                 }
+                            } else if (!GleapDetectorUtil.isIsRunning() && Gleap.getInstance() != null) {
+                                recoverSessionAndRetry(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        openHelpCenterArticle(articleId, showBackButton);
+                                    }
+                                });
                             }
                         }
                     };
@@ -898,8 +1070,7 @@ public class Gleap implements iGleap {
                     Runnable gleapRunnable = new Runnable() {
                         @Override
                         public void run() throws RuntimeException {
-                            if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null
-                                    && GleapSessionController.getInstance().isSessionLoaded()
+                            if (!GleapDetectorUtil.isIsRunning() && isGleapReady()
                                     && Gleap.getInstance() != null) {
                                 try {
 
@@ -912,6 +1083,13 @@ public class Gleap implements iGleap {
                                 } catch (Exception e) {
                                     handleError(e, "run");
                                 }
+                            } else if (!GleapDetectorUtil.isIsRunning() && Gleap.getInstance() != null) {
+                                recoverSessionAndRetry(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        openHelpCenterCollection(collectionId, showBackButton);
+                                    }
+                                });
                             }
                         }
                     };
@@ -938,8 +1116,7 @@ public class Gleap implements iGleap {
                     Runnable gleapRunnable = new Runnable() {
                         @Override
                         public void run() throws RuntimeException {
-                            if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null
-                                    && GleapSessionController.getInstance().isSessionLoaded()
+                            if (!GleapDetectorUtil.isIsRunning() && isGleapReady()
                                     && Gleap.getInstance() != null) {
                                 try {
 
@@ -952,6 +1129,13 @@ public class Gleap implements iGleap {
                                 } catch (Exception e) {
                                     handleError(e, "run");
                                 }
+                            } else if (!GleapDetectorUtil.isIsRunning() && Gleap.getInstance() != null) {
+                                recoverSessionAndRetry(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        searchHelpCenter(term, showBackButton);
+                                    }
+                                });
                             }
                         }
                     };
@@ -1738,6 +1922,14 @@ public class Gleap implements iGleap {
 
     public static class GleapListener implements OnHttpResponseListener {
         public GleapListener() {
+            this(true);
+        }
+
+        GleapListener(boolean startLoading) {
+            if (!startLoading) {
+                return;
+            }
+
             try {
                 new ConfigLoader(this).execute(GleapBug.getInstance());
 
@@ -2012,8 +2204,7 @@ public class Gleap implements iGleap {
                     Runnable gleapRunnable = new Runnable() {
                         @Override
                         public void run() throws RuntimeException {
-                            if (!GleapDetectorUtil.isIsRunning() && GleapSessionController.getInstance() != null
-                                    && GleapSessionController.getInstance().isSessionLoaded()
+                            if (!GleapDetectorUtil.isIsRunning() && isGleapReady()
                                     && Gleap.getInstance() != null) {
                                 try {
                                     JSONObject data = new JSONObject();
@@ -2024,6 +2215,13 @@ public class Gleap implements iGleap {
                                 } catch (Exception e) {
                                     handleError(e, "run");
                                 }
+                            } else if (!GleapDetectorUtil.isIsRunning() && Gleap.getInstance() != null) {
+                                recoverSessionAndRetry(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        openFeatureRequests(showBackButton);
+                                    }
+                                });
                             }
                         }
                     };

--- a/gleap/src/main/java/io/gleap/GleapBaseSessionService.java
+++ b/gleap/src/main/java/io/gleap/GleapBaseSessionService.java
@@ -17,9 +17,24 @@ import java.nio.charset.StandardCharsets;
 import javax.net.ssl.HttpsURLConnection;
 
 class GleapBaseSessionService extends AsyncTask<Void, Void, Integer> {
+    interface SessionLoadedCallback {
+        void invoke(boolean success);
+    }
+
     private static final String httpsUrl = GleapConfig.getInstance().getApiUrl() + "/sessions";
     private static final int MAX_RETRIES = 3;
     private static final long INITIAL_RETRY_DELAY_MS = 1000;
+
+    private final SessionLoadedCallback sessionLoadedCallback;
+    private boolean sessionEstablished = false;
+
+    GleapBaseSessionService() {
+        this(null);
+    }
+
+    GleapBaseSessionService(SessionLoadedCallback sessionLoadedCallback) {
+        this.sessionLoadedCallback = sessionLoadedCallback;
+    }
 
     @SuppressLint("WrongThread")
     @Override
@@ -51,13 +66,24 @@ class GleapBaseSessionService extends AsyncTask<Void, Void, Integer> {
 
         if (!success) {
             Log.e("Gleap", "All session request attempts failed after " + MAX_RETRIES + " retries", lastException);
-            
+
             if (GleapSessionController.getInstance() != null) {
                 GleapSessionController.getInstance().setSessionLoaded(true);
             }
         }
 
+        sessionEstablished = success && GleapSessionController.getInstance() != null
+                && GleapSessionController.getInstance().isSessionLoaded()
+                && GleapSessionController.getInstance().getUserSession() != null;
+
         return 200;
+    }
+
+    @Override
+    protected void onPostExecute(Integer result) {
+        if (sessionLoadedCallback != null) {
+            sessionLoadedCallback.invoke(sessionEstablished);
+        }
     }
 
     private void performSessionRequest() throws Exception {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ android.useAndroidX=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=15.4.0
-VERSION_CODE=150301
+VERSION_NAME=16.4.0
+VERSION_CODE=160400
 GROUP=io.gleap
 POM_ARTIFACT_ID=gleap-android-sdk
 POM_NAME=gleap-android-sdk


### PR DESCRIPTION
Ports the fix from GleapSDK/Gleap-iOS-SDK#27 (Gleap ticket #141630) to the Android SDK.

## Problem

When the app was launched without an internet connection, the initial config/session load failed and was never retried on demand. `Gleap.open()` and all other explicit open* calls then silently did nothing: during the first seconds the `isSessionLoaded()` gate blocked them, and after the failed retries (which mark the session as "loaded" without a real session) they died silently in `ScreenshotTaker.takeScreenshot()` because the remote config was never fetched. Mid-session connectivity loss shows an offline alert, but offline-at-launch showed nothing.

## Fix

- `isGleapReady()` now defines readiness as: session loaded **and** a real user session exists **and** the remote config is present — used by all explicit open gates.
- On an explicit (non-survey-triggered) open while not ready, `recoverSessionAndRetry()` restarts the session and, if needed, re-runs the config fetch (re-initializing detectors the same way `GleapConnectivityManager` does). On success the original open call is re-invoked and the widget opens; on failure the user gets the same "Internet not available" alert the widget shows when it fails to load mid-session.
- Survey-triggered opens keep failing silently, matching the iOS behavior.
- A static `AtomicBoolean` guards against concurrent recovery attempts.
- `GleapBaseSessionService` gained an optional callback reporting whether a session was genuinely established (the fake `setSessionLoaded(true)` failure path reports as failure).

Also bumps the SDK version to 16.4.0 for the release (including the stale `VERSION_CODE`).

## Verification

`./gradlew build` passes (compile, lint, unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)